### PR TITLE
Add React preset to Babel loader in Webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = (_env,argv)=> {
           test: /\.(js|jsx)$/,
           exclude: /(node_modules|bower_components)/,
           loader: 'babel-loader',
-          options: { presets: ['env'] }
+          options: { presets: ['env', 'react'] }
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
This fixes Babel not being able to compile JSX properly. Without adding the React preset, the build throws errors all over the place because it doesn't know what to do with the JSX syntax, e.g.:

```
ERROR in ./src/VideoOverlay.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
SyntaxError: Unexpected token (6:2)

  4 |
  5 | ReactDOM.render(
> 6 |   <App />,
    |   ^
  7 |   document.getElementById("root")
  8 | )
```